### PR TITLE
Add SCM links to Article meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-Droidstrap
-==========
+# Droidstrap
 
-A Pelican theme using bootstrap and Droid fonts.
+A Pelican theme using Bootstrap 2 and Droid fonts.
 
 Example running on [jamescooke.info](http://jamescooke.info), [screenshot here](https://raw.github.com/jamescooke/droidstrap/master/screenshot.png).
 
-
-Has
----
+## Features
 
 Theme is still in a very basic state. It has:
 
 * Basic content listing - home, tag, category.
-* Single post and single page templates.
+* Single post and single page templates. Articles can be linked to their source
+  code URLs.
 * A touch of responsiveness.
 * Tag pages.
 * Category pages.
@@ -20,29 +18,44 @@ Theme is still in a very basic state. It has:
 
 And some bugs! 
 
-
-Has not (yet)
--------------
+## Missing things
 
 * Author pages.
 * Multi language support.
 * Handling of Pelican links setting.
+* Clean and valid HTML - partly as a result of some external libraries.
 
-It's all open - contributions welcome, especially with HTML / CSS.
+It's all open - contributions welcome, especially with HTML / CSS. Please check
+out the Issues.
 
-
-Settings
---------
+## Settings
 
 We've stuck a few settings in to customise the theme.
+
+### General
 
 * `PROFILE_IMG_URL` - Set the image for the top circle cutout. (Has no default yet).
 * `TAGLINE` - Used for the page titles and some meta tags.
 
+### Article source links
 
-License & Contributors
-----------------------
+Droidstrap can link to an article's source code within a repository, for
+example, on GitHub. Update the following settings to enable this feature:
+
+* `SHOW_SCM_LINKS` - Set to `True` to turn on article source links.
+* `SCM_BASE_URL` - Set as the public URL of your blog's source tree. E.g.
+  'https://github.com/jamescooke/blog/tree/master/'
+* `SCM_LINK_TEXT` - Optional, set a text to be used for article source links.
+  Defaults to 'Article source'.
+
+Plus for each article that source should be shown a `scm_path` property should be
+added to the [article
+metadata](http://docs.getpelican.com/en/3.5.0/content.html#file-metadata). This
+should be the name of the file in the repository relative to the
+`SCM_BASE_URL`.
+
+## License & Contributors
 
 Licensed under [GNU Affero GPL 3](http://www.gnu.org/licenses/agpl.txt) - the same license as [Pelican](https://github.com/getpelican/pelican) itself.
 
-[Contributors are listed](CONTRIBUTORS.md).
+[Contributors are listed](CONTRIBUTORS.md). Thanks all!

--- a/templates/article.html
+++ b/templates/article.html
@@ -24,6 +24,11 @@
                     <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
                 {% endfor %}
             {% endif %}
+
+            {% if SHOW_SCM_LINKS and SCM_BASE_URL and article.scm_path %}
+                <br>
+                &ndash; <a href='{{ SCM_BASE_URL }}{{ article.scm_path }}'>{% if SCM_LINK_TEXT %}{{ SCM_LINK_TEXT }}{% else %}Article source{% endif %}</a>
+            {% endif %}
         </p>
 
         {% if DISQUS_SITENAME %}


### PR DESCRIPTION
Small change to the article template to add source code links in the article meta.

https://github.com/jamescooke/droidstrap/issues/7