### PR TITLE
Better unfurl

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ article.title|striptags }} // {{ super() }}{% endblock title %}
 
-{% block meta_description %}{{ article.title|striptags }}, {{ super() }}{% endblock meta_description %}
+{% block meta_description %}{{ article.summary|striptags }}{% endblock meta_description %}
 
 {% block content %}
     <section class="span7 offset1 content">

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
     <head>
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-        <meta name="description" content="{% block meta_description %}{{ SITENAME }}, {{ TAGLINE }}{% endblock meta_description %}">
+        <meta name="description" property="og:description" content="{% block meta_description %}{{ SITENAME }}, {{ TAGLINE }}{% endblock meta_description %}">
 
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/css/bootstrap.min.css">
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/css/bootstrap-responsive.min.css">
@@ -21,8 +21,8 @@
 
         {% block head %}
         <title>{% block title %}{{ SITENAME }} // {{ TAGLINE }}{% endblock title %}</title>
-            <meta charset="utf-8" />
-            <meta name="viewport" content="width=device-width">
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width">
         {% endblock head %}
     </head>
 


### PR DESCRIPTION
Two tweaks to improve the output of summaries generated by sites like Slack when sending links to a blog powered by Droidstrap.