### PR TITLE
add Pelican default categories template

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,8 @@ Contributors
 
 James Cooke ([jamescooke](https://github.com/jamescooke/))
 
+Shawn Hensley ([sahensley](https://github.com/sahensley/))
+
 Paul Richardson ([thesocialspaces](https://github.com/thesocialspaces/))
 
 Jon Staley ([jmstaley](https://github.com/jmstaley/))

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ SITENAME }} - Categories{% endblock %}
+
+{% block content %}
+    <h1>Categories on {{ SITENAME }}</h1>
+    <ul>
+    {% for category, articles in categories|sort %}
+        <li><a href="{{ SITEURL }}/{{ category.url }}">{{ category }}</a> ({{ articles|count }})</li>
+    {% endfor %}
+    </ul>
+{% endblock %}


### PR DESCRIPTION
The included categories template file is from the Pelican Simple Theme at [this commit](https://raw.githubusercontent.com/getpelican/pelican/10f70db9a6ec11fac4333c4098a8453373bf5934/pelican/themes/simple/templates/categories.html).

I also added myself (in alphabetical order) to the CONTRIBUTORS.md file.  Feel free to move my name to the bottom.  I just happened to see the list was already in alphabetical order and I wasn't sure if it was intentional or a coincidence.  

Closes #9 